### PR TITLE
Ci to ci2 merge

### DIFF
--- a/src/ci-publish-site.bsh
+++ b/src/ci-publish-site.bsh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash 
 #   Copyright 2016 Commonwealth Bank of Australia
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +41,9 @@ import lib-ci
 
 CI_Env_Adapt $(CI_Env_Get)
 
-dir=$(readlink -f $1)
+${1?"directory must be supplied"}
+dir=$(readlink_f $1)
+echo "[[[$dir]]]"
 branch="$2"
 commit_msg="$3"
 
@@ -78,7 +80,7 @@ GIT_EMAIL=${GIT_EMAIL?"is not defined"}
 GIT_USERNAME=${GIT_USERNAME?"is not defined"}
 
 echo "" >> $dir/_config.yml
-sed -i '/^releaseVersion: .*/d' $dir/_config.yml
+sed -i -e '/^releaseVersion: .*/d' $dir/_config.yml || exit 1
 echo "releaseVersion: $version" >> $dir/_config.yml
 
 if [ $CI_BRANCH = "master" ]; then

--- a/src/ci-publish-site.bsh
+++ b/src/ci-publish-site.bsh
@@ -74,11 +74,16 @@ if [ -z "$version" ]; then
     exit 1
 fi
 
+GIT_EMAIL=${GIT_EMAIL?"is not defined"}
+GIT_USERNAME=${GIT_USERNAME?"is not defined"}
+
 echo "" >> $dir/_config.yml
 sed -i '/^releaseVersion: .*/d' $dir/_config.yml
 echo "releaseVersion: $version" >> $dir/_config.yml
 
 if [ $CI_BRANCH = "master" ]; then
+    git config user.email "${GIT_EMAIL}"
+    git config user.name "${GIT_USERNAME}"
     Publish_Subdirectory_To_Branch $branch "$dir" "$commit_msg"
 else
     echoerr "Not publishing because branch is not master."

--- a/src/docker-support.bsh
+++ b/src/docker-support.bsh
@@ -1,0 +1,258 @@
+#!/bin/bash
+#   Copyright 2016 Commonwealth Bank of Australia
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# docker-support.sh setup
+#   or
+# docker-support.sh publish
+#
+# for more details, see usage below
+
+set -o pipefail
+
+IFS=$'\n\t'
+IMPORT_PATH="${BASH_SOURCE%/*}"
+if [[ ! -d "$IMPORT_PATH" ]]; then IMPORT_PATH="$PWD"; fi
+
+# Library import helper
+function import() {
+    . $IMPORT_PATH/$1
+    [ $? != 0 ] && echo "$1 import error" 1>&2 && exit 1
+}
+
+import lib-ci
+
+CI_Env_Adapt $(CI_Env_Get)
+
+function usage() {
+  echo "$0 setup | publish <options>" 1>&2
+  echo 1>&2
+  echo "The two simplest forms are '$0 setup' or '$0 publish'. All other vars are searched on the environment" 1>&2
+  echo 1>&2
+  echo "setup [-l ] -u <user> -p <password> -e <email> -r <registry_host>" 1>&2
+  echo "  -l                     - execute docker login : by default we won't login. just setup VARs" 1>&2
+  echo "                         - -l implies that registry credentials are supplied (see next)" 1>&2
+  echo "  -u <REGISTRY_USERNAME> - will look for this as ENV VAR REGISTRY_USERNAME by default" 1>&2
+  echo "  -p <REGISTRY_PASSWORD> - will look for this as ENV VAR REGISTRY_PASSWORD by default" 1>&2
+  echo "  -r <REGISTRY_HOST>     - defaults to ${REGISTRY_HOST}" 1>&2
+  echo 1>&2
+  echo "publish -e <git-email> -n <git-username> [ -i <user/docker-image> | -d <full-docker-tag> ] [ -s ]"
+  echo "  -s                    - publish the site also"
+  echo "  -e <GIT_EMAIL>        - used for _site doc publish-ing - defaults to ${GIT_EMAIL}" 1>&2
+  echo "  -n <GIT_USERNAME>     - used for _site doc publish-ing - defaults to ${GIT_USERNAME}" 1>&2
+  echo
+  echo "  -i <DOCKER_IMAGE>     - Docker tag .. user/tag" 1>&2
+  echo " OR" 1>&2
+  echo "  -d <DOCKER_TAG_NAME>  - Docker tag .. registry/user/tag" 1>&2
+}
+
+
+function indent() { 
+  echo $@ | sed 's/^/    /';
+}
+
+function log() { 
+  echo ":: $1"
+  shift
+  $@ 2>&1 | sed 's/^/    /';
+}
+
+
+function only_on_release() {
+  if [ $(Is_Release) = 0 ]; then
+    eval "$@"
+  else
+      echo "Not running command. Not a release branch"
+  fi
+}
+
+#
+# read any options passed in on the cmd line
+#
+function get_cmd_opts() {
+  while getopts "su:p:e:r:n:l" opt; do
+    case $opt in
+      u)
+        REGISTRY_USERNAME=$OPTARG
+        ;;
+      p)
+        REGISTRY_PASSWORD=${OPTARG}
+        ;;
+      n)
+        GIT_USERNAME=${OPTARG}
+        ;;
+      e)
+        GIT_EMAIL=${OPTARG}
+        ;;
+      r)
+        REGISTRY_HOST=${OPTARG}
+        ;;
+      i)
+        DOCKER_IMAGE=$OPTARG
+        ;;
+      s)
+        SITE_PUBLISH=true
+        ;;
+      l)
+        DOCKER_LOGIN=true
+        ;;
+      d)
+        DOCKER_TAG_NAME=${OPTARG}
+        ;;
+      ?)
+        echo "Invalid option: -$OPTARG" >&2
+        usage
+        exit 1
+        ;;
+      :)
+        echo "Option -$OPTARG requires an argument." >&2
+        usage
+        exit 1
+    esac
+  done
+}
+
+#
+# check and set some vars
+#
+function check_vars_base() {
+  REGISTRY_HOST=${REGISTRY_HOST?"is not defined"}
+  DOCKER_IMAGE=${DOCKER_IMAGE?"is not defined"}
+}
+
+function check_vars_auth() {
+  REGISTRY_USERNAME=${REGISTRY_USERNAME?"is not defined"}
+  REGISTRY_PASSWORD=${REGISTRY_PASSWORD?"is not defined"}
+}
+
+function check_vars_docker_login() {
+  check_vars_base
+  check_vars_auth
+}
+
+function check_vars_docker_publish() {
+  check_vars_docker_login
+  VERSION=${VERSION?"is not defined"}
+  DOCKER_TAG_NAME=${DOCKER_TAG_NAME?"is not defined"}
+}
+
+function check_vars_site_publish() {
+  GIT_EMAIL=${GIT_EMAIL?"is not defined"}
+  GIT_USERNAME=${GIT_USERNAME?"is not defined"}
+}
+
+function set_vars() {
+  DOCKER_TAG_NAME=${REGISTRY_HOST}/${DOCKER_IMAGE}:${VERSION}
+}
+
+#
+# show the vars (just important ones, not secret ones) 
+#
+function dump_vars() {
+  cat << EOF
+REGISTRY_HOST=${REGISTRY_HOST}
+VERSION=${VERSION}
+DOCKER_IMAGE=${DOCKER_IMAGE}
+DOCKER_TAG_NAME=${DOCKER_TAG_NAME}
+EOF
+
+}
+
+#
+# We create the ci_vars file for CI builds to use
+# and to make it obvious for the build what "vars" are being used
+# we dump it out to console (helps with debugging wayard builds)
+# This is used like ". ./ci-env-vars.sh"
+#
+function create_ci_vars() {
+  cat << EOF | sed 's/^\s+//g' > ci-env-vars.sh 
+     #!/bin/bash
+     export REGISTRY_HOST=${REGISTRY_HOST}
+     export VERSION=${VERSION}
+     export DOCKER_IMAGE=${DOCKER_IMAGE}
+     export DOCKER_TAG_NAME=${DOCKER_TAG_NAME}
+EOF
+
+  chmod 755 ci-env-vars.sh
+  echo "created ci-env-vars.sh"
+  echo "----------------------------------------------------"
+  cat ci-env-vars.sh
+  echo "----------------------------------------------------"
+}
+
+#
+# Setup some default vars
+#
+function setup_default_vars() {
+
+  # if the user supplied REGISTRY_HOST, it will be set here (but we check that later)
+  if [ "${CI_NAME}" = "travis" ]; then
+    REGISTRY_HOST=${REGISTRY_HOST:-commbank-docker-dockerv2-local.artifactoryonline.com}
+  fi
+
+}
+
+#----------------------------
+# main()
+#----------------------------
+
+setup_default_vars
+
+set -o errexit
+
+if [[ -z ${1+x} ]];then 
+   echo "Missing the 1st argument 'mode' (setup or publish)" 1>&2 && usage; exit 1;
+else 
+   MODE=$1
+   shift
+fi
+
+if [[ ${MODE} != "setup" && ${MODE} != "publish" ]]; then
+  echo "Invalid mode ${MODE}" 1>&2
+  usage
+  exit 1 
+fi
+
+get_cmd_opts "$@"
+
+if [[ ${MODE} == "setup" ]]; then
+  log "vars-check" check_vars_base
+  if [[ "$DOCKER_LOGIN" == "true" ]]; then
+    log "vars-check" check_vars_docker_login
+    log "docker-login -- ${REGISTRY_USERNAME}@${REGISTRY_HOST}" docker login -u ${REGISTRY_USERNAME} -p ${REGISTRY_PASSWORD} ${REGISTRY_HOST}
+  fi
+  log "set_version"
+  Version_Write_New
+  log "set_vars"
+  set_vars
+  log "show-vars" dump_vars
+  log "create_ci_vars" create_ci_vars
+fi
+
+if [[ ${MODE} == "publish" ]]; then
+  log "vars-check" check_vars_docker_publish
+  # do we need to login ? 
+  if grep --quiet ${REGISTRY_HOST} ${HOME}/.docker/config.json; then
+    log "docker-login -- already logged in ${REGISTRY_USERNAME}@${REGISTRY_HOST}" true
+  else
+    log "docker-login -- ${REGISTRY_USERNAME}@${REGISTRY_HOST}" docker login -u ${REGISTRY_USERNAME} -p ${REGISTRY_PASSWORD} ${REGISTRY_HOST}
+  fi
+  log "docker-publish -- docker push ${DOCKER_TAG_NAME}" only_on_release docker push ${DOCKER_TAG_NAME}
+  log "docker-remove" docker rmi ${DOCKER_TAG_NAME}
+  if [[ "$SITE_PUBLISH" == "true" ]]; then
+    log "vars-check" check_vars_site_publish
+    log "site-publish" $IMPORT_PATH/ci-publish-site.bsh _site
+  fi
+fi
+

--- a/src/gh-commit-comment.bsh
+++ b/src/gh-commit-comment.bsh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -9,7 +9,7 @@ set -e
 # which is part of a pull request.
 #
 # example call:
-#   ./gh-commit-comment.bsh -e http://code.br.zbi.cba/api/v3 -u zbi-ci -p xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -r ZBI/zbi-infra-dev -s ad9e0fadf1658ecf0fac0068c4e923ee26e73bc3 -f gh-comment.json
+#   ./gh-commit-comment.sh -e http://code.br.zbi.cba/api/v3 -u zbi-ci -p xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -r ZBI/zbi-infra-dev -s ad9e0fadf1658ecf0fac0068c4e923ee26e73bc3 -f gh-comment.json
 #
 # please see the comments below for details on each command line flag
 #

--- a/src/lib-ci
+++ b/src/lib-ci
@@ -68,7 +68,7 @@ function CI_Env_Get() {
     elif [ "$DRONE" = "true" ]; then
         CI_SYSTEM=DRONE
     elif [ ! -z "$ENABLE_LOCAL_CI" ]; then
-        echo "CI System could not be identified - assuming local." 1>&2
+        echo "ENABLE_LOCAL_CI is set - Assuming Local." 1>&2
         CI_SYSTEM=LOCAL
     else
         echo "CI System could not be identified." 1>&2
@@ -99,7 +99,7 @@ function CI_Env_Adapt() {
         CI_BRANCH=$DRONE_BRANCH
         CI_COMMIT=$DRONE_COMMIT
         CI_BUILD_NUMBER=$DRONE_BUILD_NUMBER
-        CI_PULL_REQUEST=$DRONE_PULL_REQUEST
+        CI_PULL_REQUEST=${DRONE_PULL_REQUEST:-false}
         CI_JOB_NUMBER=$DRONE_JOB_NUMBER
         CI_BUILD_DIR=$DRONE_BUILD_DIR
         CI_BUILD_URL=$DRONE_BUILD_URL
@@ -110,17 +110,19 @@ function CI_Env_Adapt() {
             # This is here because we want monotonically increasing job and build
             # numbers, but we have no real way to get them. Using the date like this
             # is a good compromise for local use.
+
+            # The default values ${LOCAL...:-} are to support test overrides
             referenceTime=$(date +%Y%m%d%H%M%S)
             CI_NAME=local
-            CI_REPO=$(dirname $(pwd))
-            CI_BRANCH=$(git symbolic-ref HEAD | cut -d'/' -f3-)
-            CI_COMMIT=$(git rev-parse HEAD)
-            CI_BUILD_NUMBER=$referenceTime
-            CI_PULL_REQUEST=
-            CI_JOB_NUMBER=$referenceTime
-            CI_BUILD_DIR=$(pwd)
-            CI_BUILD_URL=
-            CI_TAG=$(git name-rev --name-only --tags HEAD | sed 's/^undefined$//')
+            CI_REPO=${LOCAL_REPO:-$(dirname $(pwd))}
+            CI_BRANCH=${LOCAL_BRANCH:-$(git symbolic-ref HEAD | cut -d'/' -f3-)}
+            CI_COMMIT=${LOCAL_COMMIT:-$(git rev-parse HEAD)}
+            CI_BUILD_NUMBER=${LOCAL_BUILD_NUMBER:-$referenceTime}
+            CI_PULL_REQUEST=${LOCAL_PULL_REQUEST:-false}
+            CI_JOB_NUMBER=${LOCAL_JOB_NUMBER:-$referenceTime}
+            CI_BUILD_DIR=${LOCAL_BUILD_DIR:-$(pwd)}
+            CI_BUILD_URL=${LOCAL_BUILD_URL:-""}
+            CI_TAG=${LOCAL_TAG:-$(git name-rev --name-only --tags HEAD | sed 's/^undefined$//')}
         else
             echo "CI System could not be identified. Failing." 1>&2
             exit 1
@@ -236,7 +238,7 @@ Publish_Subdirectory_To_Branch() {
     local commit_msg="$3"
     local remote="$4"
     
-    local directory="$(readlink -f $input_directory)"
+    local directory="$(readlink_f $input_directory)"
 
     if [ -z "$remote" ]; then
         # Figure out a default remote, or fail.
@@ -295,6 +297,37 @@ Publish_Subdirectory_To_Branch() {
     
     export GIT_DIR=$ORIG_GIT_DIR
     export GIT_WORK_TREE=$ORIG_GIT_WORK_TREE
+}
+
+#
+# we need a portable way of creating temp dirs and files on OSX and Linux
+#
+function Mktemp_Portable() {
+
+  local tmptype=$1 # file or dir
+  local tmppath=${2:-${TMPDIR:-/tmp}} # root path (optional) .. defaults to TMPDIR
+  local caller=$( basename $0 )
+
+  local tmpTemplate="${tmppath}/_tmp-${caller}.XXXXXXXXX"
+
+  if [[ ${tmptype} == "file" ]]; then 
+    theTmp=$( mktemp "${tmpTemplate}" )
+  elif [[ ${tmptype} == "dir" ]]; then 
+    theTmp=$( mktemp -d "${tmpTemplate}" )
+  else 
+    echo "usage: Mktemp_Portable [ file | dir ]" 1>&2 
+    exit 1
+  fi
+  echo ${theTmp}
+
+}
+
+#
+# readlink -f compatible OSX/Linux
+#
+
+readlink_f() {
+  perl -MCwd -e 'print (Cwd::abs_path shift); print "\n";' "$1"
 }
 
 set +o nounset

--- a/src/lib-ci
+++ b/src/lib-ci
@@ -162,7 +162,7 @@ function Version_Get() {
         exit 1
     fi
 
-    local branch=$CI_BRANCH
+    local branch=${CI_BRANCH//[^[:alnum:]_.-]/_}
     local ts=$(date "+%Y%m%d%H%M%S")
     local commitish=${CI_COMMIT:0:7}
     local version="$source_version-$ts-$commitish"
@@ -176,13 +176,31 @@ function Version_Get() {
     fi
 }
 
+# Generate a new VERSION file
+# Will check for the VERSION file existing. Errors if not found
+function Version_Write_New() {
+  if [[ ! -f ${PWD}/VERSION ]]; then
+      echo "${PWD}/VERSION file not found." 1>&2
+      exit 1
+  fi
+
+  new_version=$(Version_Get $(cat VERSION))
+  if [[ -z $new_version ]]; then
+      exit 1
+  fi
+  echo "Version Mapped: $version => $new_version"
+  echo "$new_version" > VERSION
+  VERSION=$new_version
+}
+
+
 # Checks if we are on a release branch.
 # Returns 0 iff we are on a release branch and 1 otherwise.
 # Master is a release branch by default.
 function Is_Release() {
     CI_Env_Adapt $(CI_Env_Get)
 
-    if [ $CI_BRANCH == "master" ]; then
+    if [[ $CI_BRANCH == "master" && $CI_PULL_REQUEST == false ]]; then
       echo 0
     elif [[ $CI_PULL_REQUEST == false && $(Array_Contains "$CI_BRANCH" "${RELEASE_BRANCHES[@]}") == 0 ]]; then
         echo 0

--- a/src/sbt-ci-build-doc.bsh
+++ b/src/sbt-ci-build-doc.bsh
@@ -68,10 +68,10 @@ sed -i '/^releaseVersion: .*/d' src/site/_config.yml
 echo "releaseVersion: $version" >> src/site/_config.yml
 
 if [ -z $SBT ]; then
-    if [ -x "./sbt" ]; then
-        SBT="./sbt"
-    elif [ -x "sbt" ]; then
+    if [ -x "sbt" ]; then
         SBT="sbt"
+    elif [ -x "./sbt" ]; then
+        SBT="./sbt"
     else
         echoerr "sbt is not specified by SBT env var, nor found. Aborting."
         exit 1

--- a/src/sbt-ci-build-doc.bsh
+++ b/src/sbt-ci-build-doc.bsh
@@ -68,10 +68,11 @@ sed -i '/^releaseVersion: .*/d' src/site/_config.yml
 echo "releaseVersion: $version" >> src/site/_config.yml
 
 if [ -z $SBT ]; then
-    if [ -x "sbt" ]; then
-        SBT="sbt"
-    elif [ -x "./sbt" ]; then
+    sbtOnPath=$( which sbt )
+    if [ -x "./sbt" ]; then
         SBT="./sbt"
+    elif [ -x "${sbtOnPath}" ]; then
+        SBT="${sbtOnPath}"
     else
         echoerr "sbt is not specified by SBT env var, nor found. Aborting."
         exit 1

--- a/src/setup-version.bsh
+++ b/src/setup-version.bsh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 #   Copyright 2014 Commonwealth Bank of Australia
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,16 +28,6 @@ function import() {
 
 import lib-ci
 
-if [ ! -f VERSION ]; then
-    echo "VERSION file not found." 1>&2
-    exit 1
-fi
-
-new_version=$(Version_Get $(cat VERSION))
-if [ -z $new_version ]; then
-    exit 1
-fi
-echo "Version Mapped: $version => $new_version"
-echo "$new_version" > VERSION
+Version_Write_New
 
 exit 0

--- a/src/setup-version.bsh
+++ b/src/setup-version.bsh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 #   Copyright 2014 Commonwealth Bank of Australia
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test.bsh
+++ b/src/test.bsh
@@ -1,14 +1,41 @@
 #!/bin/bash
 
-# Always show the CI env
-echo "Dumping CI environment..."
 . ./lib-ci
-CI_Env_Dump
 
-# Run the tests
-for i in $(find tests -mindepth 1 -name 't*' -type f -print | sort); do
-    bash $i
-    if [ $? != 0 ]; then
-        exit 1
-    fi
-done
+function init() {
+  # Always show the CI env
+  echo ":: [$0] Dumping CI environment..."
+  CI_Env_Dump
+}
+
+function cleanup() {
+  # 
+  # all tests create .tmp-blah directories
+  # we remote them here for purity
+  #
+  echo ":: [$0] cleanup temp dirs"
+  find . -name '_tmp-*' | xargs -L1 -Ixx sh -c 'echo "rm -rf xx"  && rm -rf xx'
+}
+
+function run_tests() {
+  # Run the tests
+  for i in $(find tests -mindepth 1 -name 'test-*' -type f -print | sort); do
+      echo ":: [$0] $i"
+      bash $i
+      if [ $? != 0 ]; then
+          echo ":: [$0] previous test [$i] failed - not continuing"
+          cleanup
+          exit 1
+      fi
+  done
+  echo ":: [$0] All tests complete."
+}
+
+#
+# main()
+#
+init
+run_tests
+cleanup
+
+

--- a/src/tests/test-ci-publish-site.bsh
+++ b/src/tests/test-ci-publish-site.bsh
@@ -41,7 +41,9 @@ WVFAIL ../ci-publish-site.bsh "$TMPBASE/site" "gh-pages" "Commit Msg"
 touch VERSION
 WVFAIL ../ci-publish-site.bsh "$TMPBASE/site" "gh-pages" "Commit Msg"
 
-# Should pass when a version file exists
+# Should pass when a version file exists and the GIT_USERNAME and GIT_EMAIL
+export GIT_EMAIL="zbi+test@cba.com.au"
+export GIT_USERNAME="WVTEST"
 echo "1.0.0" >> VERSION
 WVPASS ../ci-publish-site.bsh "$TMPBASE/site" "gh-pages" "Commit Msg"
 

--- a/src/tests/test-ci-publish-site.bsh
+++ b/src/tests/test-ci-publish-site.bsh
@@ -6,17 +6,19 @@
 
 . ./lib-ci
 
+SCRIPTS_DIR=${PWD}
+
 # This is our fake remote repo to send documentation to
-TMPREMOTE=$(mktemp -d -p $(pwd) tmp-ci-publish-site_remote-XXXXXXXX)
+TMPREMOTE=$( Mktemp_Portable dir )
 atexit '[ ! -z "$TMPREMOTE" ] && rm -rf $TMPREMOTE'
 git init --bare $TMPREMOTE || exit 1
 
 # Base directory for test
-TMPBASE=$(mktemp -d -p $(pwd) tmp-ci-publish-site_base-XXXXXXXX)
+TMPBASE=$( Mktemp_Portable dir )
 atexit '[ ! -z "$TMPBASE" ] && rm -rf $TMPBASE'
 
 # Setup a test git repository in here.
-cd $TMPBASE
+cd $TMPBASE || exit 1
 atexit cd $(pwd)
 
 touch .gitkeep
@@ -31,27 +33,27 @@ git commit -m "Initial commit" || exit 1
 git symbolic-ref HEAD refs/heads/master || exit 1
 git remote add origin $TMPREMOTE || exit 1
 
-cd $TMPBASE
+cd $TMPBASE || exit 1
 atexit cd $(pwd)
 
 # Check we fail when no VERSION
-WVFAIL ../ci-publish-site.bsh "$TMPBASE/site" "gh-pages" "Commit Msg"
+WVFAIL ${SCRIPTS_DIR}/ci-publish-site.bsh "$TMPBASE/site" "gh-pages" "Commit Msg"
 
 # Check fail when empty VERSION
 touch VERSION
-WVFAIL ../ci-publish-site.bsh "$TMPBASE/site" "gh-pages" "Commit Msg"
+WVFAIL ${SCRIPTS_DIR}/ci-publish-site.bsh "$TMPBASE/site" "gh-pages" "Commit Msg"
 
 # Should pass when a version file exists and the GIT_USERNAME and GIT_EMAIL
 export GIT_EMAIL="zbi+test@cba.com.au"
 export GIT_USERNAME="WVTEST"
 echo "1.0.0" >> VERSION
-WVPASS ../ci-publish-site.bsh "$TMPBASE/site" "gh-pages" "Commit Msg"
+WVPASS ${SCRIPTS_DIR}/ci-publish-site.bsh "$TMPBASE/site" "gh-pages" "Commit Msg"
 
 # Check the we end up with something sensible in the base directory
 WVPASS [ -e "$TMPBASE/site/_config.yml" ]
 WVPASS grep 'releaseVersion' $TMPBASE/site/_config.yml
 
 # Do a bunch of WVFAIL tests for command line parsing 
-WVFAIL ../ci-publish-site.bsh nonexistent
-WVFAIL ../ci-publish-site.bsh
+WVFAIL ${SCRIPTS_DIR}/ci-publish-site.bsh nonexistent
+WVFAIL ${SCRIPTS_DIR}/ci-publish-site.bsh
 

--- a/src/tests/test-ci-release.bsh
+++ b/src/tests/test-ci-release.bsh
@@ -9,17 +9,17 @@
 # get_CI_env tests
 CI_SYSTEM=$(CI_Env_Get)
 
-TMPPATH=$(TMPDIR=. mktemp tmpdockermake-pathXXXXXXXX)
+TMPFILE=$( Mktemp_Portable file )
 
 # Tests that the command will be run on release branches
 export ${CI_SYSTEM}_BRANCH=master
 export ${CI_SYSTEM}_PULL_REQUEST=false
-WVPASS ./ci-release.bsh touch $TMPPATH
-WVPASS test -e $TMPPATH
-rm $TMPPATH
+WVPASS ./ci-release.bsh touch $TMPFILE
+WVPASS test -e $TMPFILE
+rm $TMPFILE
 
 # Tests that the command will not be run on release branches
 export ${CI_SYSTEM}_BRANCH=testbranch
 export ${CI_SYSTEM}_PULL_REQUEST=false
-WVPASS ./ci-release.bsh touch $TPMPATH
-WVFAIL test -e $TMPPATH
+WVPASS ./ci-release.bsh touch $TMPFILE
+WVFAIL test -e $TMPFILE

--- a/src/tests/test-docker-support.bsh
+++ b/src/tests/test-docker-support.bsh
@@ -1,0 +1,238 @@
+#!/bin/bash -u
+# Test the docker-support script.
+
+# Test framework
+
+echo "-------------- $0"
+. ./wvtest.sh
+
+. ./lib-ci
+
+# get_CI_env tests
+CI_SYSTEM=$(CI_Env_Get)
+
+ORIG_PATH=$PATH
+
+TMPDIR=$(mktemp -d -p . tmpdockersupport-dirXXXXXXXX)
+TMPPATH=$(mktemp -d -p . tmpdockersupport-pathXXXXXXXX)
+
+echo WD=$TMPDIR
+echo TMPPATH=$TMPPATH
+
+#--------------------- Setup Fake environment -------------
+cd $TMPDIR
+export PATH=../$TMPPATH:$ORIG_PATH
+
+#
+# get a few things
+#
+cp ../docker-support.bsh .
+cp ../lib-ci .
+cp ../setup-version.bsh .
+touch ci-publish-site.bsh 
+chmod +x ci-publish-site.bsh
+
+#----------------------------------------------------
+# Setup - create a fake docker binary to check the command invocation
+#----------------------------------------------------
+
+# Setup a fake docker path
+touch ../$TMPPATH/docker
+chmod +x ../$TMPPATH/docker
+
+#
+#
+cat << EOF > ../$TMPPATH/docker
+#!/bin/bash
+# This is a fake docker binary for testing purposes.
+echo "fake-docker: \$@"
+MODE=\$1
+if [[ "\$MODE" == "login" ]]; then 
+  echo "fake login >> \$HOME/.docker/config.json"
+  [ -d \$HOME/.docker ] || mkdir \$HOME/.docker
+  echo \$REGISTRY_HOST > \$HOME/.docker/config.json
+fi
+echo \$@ > ../$TMPDIR/TEST_docker-\$MODE
+EOF
+
+#
+#
+cat << EOF > ci-publish-site.bsh
+#!/bin/bash
+echo "fake-site-publish: \$@"
+echo \$@ > ../$TMPDIR/TEST_ci-publish-site
+EOF
+
+#--------------------- Perform Tests -------------
+# Check the script fails properly
+#----------------------------------------------------
+
+WVFAIL ./docker-support.bsh
+WVFAIL ./docker-support.bsh unsupported
+
+#----------------------------------------------------
+# setup - test artefact version file
+#----------------------------------------------------
+
+echo "1.2.3" > VERSION
+versionOrig=$( cat VERSION )
+
+#----------------------------------------------------
+# Invalid VAR check tests
+#----------------------------------------------------
+# these should fail because a few environment vars are not setup
+
+WVFAIL ./docker-support.bsh setup 
+WVFAIL ./docker-support.bsh publish
+
+# now let's get specific
+# ---- setup tests
+WVFAIL ./docker-support.bsh setup 
+export REGISTRY_HOST=someserver.foobar
+WVFAIL ./docker-support.bsh setup 
+export DOCKER_IMAGE=build/my-special-docker
+WVPASS ./docker-support.bsh setup 
+
+
+# user/pass for a login
+WVFAIL ./docker-support.bsh setup -l
+export REGISTRY_USERNAME=user
+WVFAIL ./docker-support.bsh setup -l
+export REGISTRY_PASSWORD=user
+WVPASS ./docker-support.bsh setup -l
+
+# ---- publish tests
+#
+# Should fail a login
+# no file created
+
+#
+# given that setup has now passed. Let's simulate the real
+CI_Env_Adapt $(CI_Env_Get)
+
+export RELEASE_BRANCHES=${CI_BRANCH}
+export ${CI_SYSTEM}_PULL_REQUEST=false 
+. ./ci-env-vars.sh
+
+#
+rm $HOME/.docker/config.json
+unset REGISTRY_USERNAME
+unset REGISTRY_PASSWORD
+WVFAIL ./docker-support.bsh publish
+WVPASS [ ! -f $HOME/.docker/config.json ]
+
+#
+# Should succeed a login
+#
+export REGISTRY_USERNAME=user
+export REGISTRY_PASSWORD=password
+WVPASS ./docker-support.bsh publish 
+WVPASS [ -f $HOME/.docker/config.json ]
+
+WVFAIL ./docker-support.bsh publish -s
+export GIT_EMAIL=some_email@somewhere.com.foo
+export GIT_USERNAME=mygituser
+WVPASS ./docker-support.bsh publish -s
+
+# ^^ all env vars are setup now, so it will work in the next run
+
+#----------------------------------------------------
+# test - perform the setup but no login should have occurred
+#----------------------------------------------------
+
+rm ../$TMPDIR/TEST_docker-login
+rm $HOME/.docker/config.json
+WVPASS ./docker-support.bsh setup
+# make sure that login was not attempted
+WVPASS [ ! -f ./$TMPDIR/TEST_docker-login ]
+WVPASS [ ! -f $HOME/.docker/config.json ]
+
+#----------------------------------------------------
+# test - Was docker login called ? 
+#----------------------------------------------------
+WVPASS ./docker-support.bsh setup -l
+dockerArgs=( $(cat ../$TMPDIR/TEST_docker-login) )
+expected=(\
+    "login" \
+    "-u" \
+    "${REGISTRY_USERNAME}" \
+    "-p" \
+    "${REGISTRY_PASSWORD}" \
+    "${REGISTRY_HOST}" \
+)
+WVPASSEQ "$(echo ${dockerArgs[@]})" "$(echo ${expected[@]})"
+WVPASS [ -f $HOME/.docker/config.json ]
+
+#----------------------------------------------------
+# test - calling docker-support.sh calls creates  VERSION file .. so that should have happened
+#        Check command modifies version
+#----------------------------------------------------
+
+versionNew=$( cat VERSION )
+WVPASSNE "$versionNew" "$versionOrig"
+
+#----------------------------------------------------
+# test - the setup creates an environments file for .drone.yml .travis.yml import (. ./ci-env-vars.sh )
+#        let's check it
+#----------------------------------------------------
+
+WVPASS [ -f ci-env-vars.sh ]
+envVars=( $(cat ci-env-vars.sh) )
+expected=(\
+    "#!/bin/bash" \
+    "export REGISTRY_HOST=${REGISTRY_HOST}" \
+    "export VERSION=${versionNew}" \
+    "export DOCKER_IMAGE=${DOCKER_IMAGE}" \
+    "export DOCKER_TAG_NAME=${REGISTRY_HOST}/${DOCKER_IMAGE}:${versionNew}" \
+)
+WVPASSEQ "$(echo ${envVars[@]})" "$(echo ${expected[@]})"
+
+#----------------------------------------------------
+# test - docker-support.bsh publish will call 'docker push ${DOCKER_TAG_NAME}' - but only on a release branch
+#        so we will test that - we have the fake docker shell script going
+#----------------------------------------------------
+
+# for the test
+. ./ci-env-vars.sh
+
+WVPASS ./docker-support.bsh publish -s
+pushArgs=( $(cat ../$TMPDIR/TEST_docker-push) )
+expected=(\
+    "push" \
+    "${REGISTRY_HOST}/${DOCKER_IMAGE}:${versionNew}" \
+)
+WVPASSEQ "$(echo ${pushArgs[@]})" "$(echo ${expected[@]})"
+
+#----------------------------------------------------
+# test - docker-support.bsh will call ci-publish-site,bsh .. so lets make sure that was called
+#----------------------------------------------------
+
+sitePublish=(  $( cat ../$TMPDIR/TEST_ci-publish-site ) )
+expected=( "_site" )
+WVPASSEQ "$(echo ${sitePublish[@]})" "$(echo ${expected[@]})"
+
+#----------------------------------------------------
+# should not publish if not passed a -s
+#----------------------------------------------------
+rm ../$TMPDIR/TEST_ci-publish-site
+WVPASS ./docker-support.bsh publish 
+WVPASS [ ! -f ../$TMPDIR/TEST_ci-publish-site ]
+
+#----------------------------------------------------
+# test - check rmi was called
+#----------------------------------------------------
+
+dockerRmiArgs=( $(cat ../$TMPDIR/TEST_docker-rmi) )
+expected=(\
+    "rmi" \ 
+    "${DOCKER_TAG_NAME}" \
+)
+WVPASSEQ "$(echo ${dockerRmiArgs[@]})" "$(echo ${expected[@]})"
+
+#----------------------------------------------------
+# Cleanup
+#----------------------------------------------------
+cd ..
+rm -rf $TMPPATH $TMPDIR 
+
+echo "-------------- END $0"

--- a/src/tests/test-docker-support.bsh
+++ b/src/tests/test-docker-support.bsh
@@ -13,15 +13,14 @@ CI_SYSTEM=$(CI_Env_Get)
 
 ORIG_PATH=$PATH
 
-TMPDIR=$(mktemp -d -p . tmpdockersupport-dirXXXXXXXX)
-TMPPATH=$(mktemp -d -p . tmpdockersupport-pathXXXXXXXX)
+MYTMPDIR=$( Mktemp_Portable dir ${PWD} )
+MYTMPPATH=$( Mktemp_Portable dir ${PWD} )
 
-echo WD=$TMPDIR
-echo TMPPATH=$TMPPATH
+echo MYTMPPATH=$MYTMPPATH
 
 #--------------------- Setup Fake environment -------------
-cd $TMPDIR
-export PATH=../$TMPPATH:$ORIG_PATH
+cd $MYTMPDIR
+export PATH=$MYTMPPATH:$ORIG_PATH
 
 #
 # get a few things
@@ -37,12 +36,12 @@ chmod +x ci-publish-site.bsh
 #----------------------------------------------------
 
 # Setup a fake docker path
-touch ../$TMPPATH/docker
-chmod +x ../$TMPPATH/docker
+touch $MYTMPPATH/docker
+chmod +x $MYTMPPATH/docker
 
 #
 #
-cat << EOF > ../$TMPPATH/docker
+cat << EOF > $MYTMPPATH/docker
 #!/bin/bash
 # This is a fake docker binary for testing purposes.
 echo "fake-docker: \$@"
@@ -52,7 +51,7 @@ if [[ "\$MODE" == "login" ]]; then
   [ -d \$HOME/.docker ] || mkdir \$HOME/.docker
   echo \$REGISTRY_HOST > \$HOME/.docker/config.json
 fi
-echo \$@ > ../$TMPDIR/TEST_docker-\$MODE
+echo \$@ > $MYTMPDIR/TEST_docker-\$MODE
 EOF
 
 #
@@ -60,7 +59,7 @@ EOF
 cat << EOF > ci-publish-site.bsh
 #!/bin/bash
 echo "fake-site-publish: \$@"
-echo \$@ > ../$TMPDIR/TEST_ci-publish-site
+echo \$@ > $MYTMPDIR/TEST_ci-publish-site
 EOF
 
 #--------------------- Perform Tests -------------
@@ -111,7 +110,7 @@ WVPASS ./docker-support.bsh setup -l
 CI_Env_Adapt $(CI_Env_Get)
 
 export RELEASE_BRANCHES=${CI_BRANCH}
-export ${CI_SYSTEM}_PULL_REQUEST=false 
+export CI_PULL_REQUEST=false 
 . ./ci-env-vars.sh
 
 #
@@ -140,18 +139,18 @@ WVPASS ./docker-support.bsh publish -s
 # test - perform the setup but no login should have occurred
 #----------------------------------------------------
 
-rm ../$TMPDIR/TEST_docker-login
+rm $MYTMPDIR/TEST_docker-login
 rm $HOME/.docker/config.json
 WVPASS ./docker-support.bsh setup
 # make sure that login was not attempted
-WVPASS [ ! -f ./$TMPDIR/TEST_docker-login ]
+WVPASS [ ! -f ./$MYTMPDIR/TEST_docker-login ]
 WVPASS [ ! -f $HOME/.docker/config.json ]
 
 #----------------------------------------------------
 # test - Was docker login called ? 
 #----------------------------------------------------
 WVPASS ./docker-support.bsh setup -l
-dockerArgs=( $(cat ../$TMPDIR/TEST_docker-login) )
+dockerArgs=( $(cat $MYTMPDIR/TEST_docker-login) )
 expected=(\
     "login" \
     "-u" \
@@ -194,9 +193,11 @@ WVPASSEQ "$(echo ${envVars[@]})" "$(echo ${expected[@]})"
 
 # for the test
 . ./ci-env-vars.sh
+export ${CI_SYSTEM}_BRANCH=master
+export ${CI_SYSTEM}_PULL_REQUEST=false
 
 WVPASS ./docker-support.bsh publish -s
-pushArgs=( $(cat ../$TMPDIR/TEST_docker-push) )
+pushArgs=( $(cat $MYTMPDIR/TEST_docker-push) )
 expected=(\
     "push" \
     "${REGISTRY_HOST}/${DOCKER_IMAGE}:${versionNew}" \
@@ -207,22 +208,22 @@ WVPASSEQ "$(echo ${pushArgs[@]})" "$(echo ${expected[@]})"
 # test - docker-support.bsh will call ci-publish-site,bsh .. so lets make sure that was called
 #----------------------------------------------------
 
-sitePublish=(  $( cat ../$TMPDIR/TEST_ci-publish-site ) )
+sitePublish=(  $( cat $MYTMPDIR/TEST_ci-publish-site ) )
 expected=( "_site" )
 WVPASSEQ "$(echo ${sitePublish[@]})" "$(echo ${expected[@]})"
 
 #----------------------------------------------------
 # should not publish if not passed a -s
 #----------------------------------------------------
-rm ../$TMPDIR/TEST_ci-publish-site
+rm $MYTMPDIR/TEST_ci-publish-site
 WVPASS ./docker-support.bsh publish 
-WVPASS [ ! -f ../$TMPDIR/TEST_ci-publish-site ]
+WVPASS [ ! -f $MYTMPDIR/TEST_ci-publish-site ]
 
 #----------------------------------------------------
 # test - check rmi was called
 #----------------------------------------------------
 
-dockerRmiArgs=( $(cat ../$TMPDIR/TEST_docker-rmi) )
+dockerRmiArgs=( $(cat $MYTMPDIR/TEST_docker-rmi) )
 expected=(\
     "rmi" \ 
     "${DOCKER_TAG_NAME}" \
@@ -233,6 +234,6 @@ WVPASSEQ "$(echo ${dockerRmiArgs[@]})" "$(echo ${expected[@]})"
 # Cleanup
 #----------------------------------------------------
 cd ..
-rm -rf $TMPPATH $TMPDIR 
+rm -rf $MYTMPPATH $MYTMPDIR 
 
 echo "-------------- END $0"

--- a/src/tests/test-dockermake.bsh
+++ b/src/tests/test-dockermake.bsh
@@ -6,17 +6,21 @@
 
 ORIG_PATH=$PATH
 
-TMPDIR=$(mktemp -d -p . tmpdockermake-tmpXXXXXXXX)
-TMPPATH=$(mktemp -d -p . tmpdockermake-pathXXXXXXXX)
+TMPDIR=$PWD/$(mktemp -d -p . tmpdockermake-tmpXXXXXXXX)
+TMPPATH=$PWD/$(mktemp -d -p . tmpdockermake-pathXXXXXXXX)
 export PATH=$TMPPATH:$ORIG_PATH
 
 # Setup a fake docker path
 touch $TMPPATH/docker
 chmod +x $TMPPATH/docker
 
+WORKDIR=$(mktemp -d -p . workdockermake-tmpXXXXXXXX)
+
+cd $WORKDIR
+
 # Check the script fails properly
-WVFAIL ./dockermake.bsh
-WVFAIL ./dockermake.bsh unsupported
+WVFAIL ../dockermake.bsh
+WVFAIL ../dockermake.bsh unsupported
 
 # Test docker build part
 mkdir tmpDOCKERIMAGE
@@ -41,7 +45,7 @@ EOF
 
 # Do a build then check the file fake-docker writes to see what the input args
 # were.
-WVPASS ./dockermake.bsh build --build-arg=somearg1=somevalue1 \
+WVPASS ../dockermake.bsh build --build-arg=somearg1=somevalue1 \
         --build-arg somearg2=somevalue2
 
 # Image 1
@@ -106,7 +110,8 @@ exit 0
 EOF
 chmod +x $TMPPATHORDER/docker
 
-WVPASS ./dockermake.bsh build tmpDOCKERIMAGEyyy tmpDOCKERIMAGExxx
+WVPASS ../dockermake.bsh build tmpDOCKERIMAGEyyy tmpDOCKERIMAGExxx
 
-rm -rf $TMPPATH $TMPDIR $TMPPATHORDER tmpDOCKERIMAGEyyy tmpDOCKERIMAGExxx \
-    tmpDOCKERIMAGE tmpDOCKERIMAGE2
+cd ..
+
+rm -rf $TMPPATH $TMPDIR $TMPPATHORDER $WORKDIR

--- a/src/tests/test-dockermake.bsh
+++ b/src/tests/test-dockermake.bsh
@@ -4,23 +4,28 @@
 # Test framework
 . ./wvtest.sh
 
-ORIG_PATH=$PATH
+. ./lib-ci
 
-TMPDIR=$PWD/$(mktemp -d -p . tmpdockermake-tmpXXXXXXXX)
-TMPPATH=$PWD/$(mktemp -d -p . tmpdockermake-pathXXXXXXXX)
+
+ORIG_PATH=$PATH
+SCRIPT_DIR=${PWD}
+
+MYTMPDIR=$( Mktemp_Portable dir ${PWD} )
+TMPPATH=$( Mktemp_Portable dir ${PWD} )
+
 export PATH=$TMPPATH:$ORIG_PATH
 
 # Setup a fake docker path
 touch $TMPPATH/docker
 chmod +x $TMPPATH/docker
 
-WORKDIR=$(mktemp -d -p . workdockermake-tmpXXXXXXXX)
+WORKDIR=$( Mktemp_Portable dir ${PWD} )
 
 cd $WORKDIR
 
 # Check the script fails properly
-WVFAIL ../dockermake.bsh
-WVFAIL ../dockermake.bsh unsupported
+WVFAIL ${SCRIPT_DIR}/dockermake.bsh
+WVFAIL ${SCRIPT_DIR}/dockermake.bsh unsupported
 
 # Test docker build part
 mkdir tmpDOCKERIMAGE
@@ -40,16 +45,16 @@ echo "fake-docker: \$@"
 for i in \$@; do
     dest=result_\$i
 done
-echo \$@ > $TMPDIR/\$dest
+echo \$@ > $MYTMPDIR/\$dest
 EOF
 
 # Do a build then check the file fake-docker writes to see what the input args
 # were.
-WVPASS ../dockermake.bsh build --build-arg=somearg1=somevalue1 \
+WVPASS ${SCRIPT_DIR}/dockermake.bsh build --build-arg=somearg1=somevalue1 \
         --build-arg somearg2=somevalue2
 
 # Image 1
-dockerArgs=( $(cat $TMPDIR/result_tmpDOCKERIMAGE) )
+dockerArgs=( $(cat $MYTMPDIR/result_tmpDOCKERIMAGE) )
 
 expected=(\
     "build" \
@@ -67,7 +72,7 @@ expected=(\
 WVPASSEQ "$(echo ${dockerArgs[@]})" "$(echo ${expected[@]})"
 
 # Image 2
-dockerArgs=( $(cat $TMPDIR/result_tmpDOCKERIMAGE2) )
+dockerArgs=( $(cat $MYTMPDIR/result_tmpDOCKERIMAGE2) )
 
 expected=(\
     "build" \
@@ -86,7 +91,7 @@ WVPASSEQ "$(echo ${dockerArgs[@]})" "$(echo ${expected[@]})"
 
 # Test building images in the order they are specified on the command line
 # and also only the command line specified ones.
-TMPPATHORDER=$(mktemp -d -p . tmpdockermake-pathXXXXXXXX)
+TMPPATHORDER=$( Mktemp_Portable dir ${PWD} )
 export PATH=$TMPPATHORDER:$ORIG_PATH
 
 # Pre-req
@@ -101,17 +106,17 @@ touch tmpDOCKERIMAGExxx/Dockerfile
 cat << EOF > $TMPPATHORDER/docker
 #!/bin/bash
 # Check if the pre-req file generated first
-[ "\$7" = "tmpDOCKERIMAGExxx" ] && [ ! -e "$TMPDIR/result_tmpDOCKERIMAGEyyy" ] && exit 1
+[ "\$7" = "tmpDOCKERIMAGExxx" ] && [ ! -e "$MYTMPDIR/result_tmpDOCKERIMAGEyyy" ] && exit 1
 
 # This is a fake docker binary for testing purposes.
 echo "fake-docker: \$@"
-echo \$@ > $TMPDIR/result_\$7
+echo \$@ > $MYTMPDIR/result_\$7
 exit 0
 EOF
 chmod +x $TMPPATHORDER/docker
 
-WVPASS ../dockermake.bsh build tmpDOCKERIMAGEyyy tmpDOCKERIMAGExxx
+WVPASS ${SCRIPT_DIR}/dockermake.bsh build tmpDOCKERIMAGEyyy tmpDOCKERIMAGExxx
 
 cd ..
 
-rm -rf $TMPPATH $TMPDIR $TMPPATHORDER $WORKDIR
+rm -rf $TMPPATH $MYTMPDIR $TMPPATHORDER $WORKDIR

--- a/src/tests/test-lib-ci.bsh
+++ b/src/tests/test-lib-ci.bsh
@@ -26,6 +26,15 @@ export ${CI_SYSTEM}_PULL_REQUEST=false
 echo $(Version_Get 1.0.0) > NEW_VERSION
 echo "NEW_VERSION=$(cat NEW_VERSION)"
 WVPASS grep -oP "1.0.0-\d{14}-adc83b1" NEW_VERSION
+rm NEW_VERSION
+
+# On a branch with a / in the name
+export ${CI_SYSTEM}_BRANCH=test/branch
+export ${CI_SYSTEM}_PULL_REQUEST=false
+echo $(Version_Get 1.0.0) > NEW_VERSION
+echo "NEW_VERSION=$(cat NEW_VERSION)"
+WVPASS grep -oE "1.0.0-[0-9]{14}-adc83b1-test_branch" NEW_VERSION
+rm NEW_VERSION
 
 # On a branch
 export ${CI_SYSTEM}_BRANCH=testbranch
@@ -68,6 +77,12 @@ unset RELEASE_BRANCHES
 echo "IS_RELEASE=$(Is_Release)"
 WVPASS [ $(Is_Release) == 1 ]
 
+# Pull request to a release branch
+export ${CI_SYSTEM}_BRANCH=master
+export ${CI_SYSTEM}_PULL_REQUEST=true
+echo "IS_RELEASE=$(Is_Release)"
+WVPASS [ $(Is_Release) == 1 ]
+
 # Local CI should be enabled when we enable the flag
 export ENABLE_LOCAL_CI=yes
 WVPASS CI_Env_Adapt "LOCAL"
@@ -103,4 +118,3 @@ chmod +x .test_lib_ci_atexit_fail.bsh
 WVPASS ./.test_lib_ci_atexit_fail.bsh
 WVPASS [ ! -e .made_by_atexit ]
 rm .test_lib_ci_atexit_fail.bsh
-

--- a/src/tests/test-lib-ci.bsh
+++ b/src/tests/test-lib-ci.bsh
@@ -5,6 +5,9 @@
 . ./wvtest.sh
 
 . ./lib-ci
+
+MYTMPDIR=$( Mktemp_Portable dir ${PWD} )
+
 WVPASSEQ "$?" "0"
 
 # get_CI_env tests
@@ -19,13 +22,15 @@ WVPASS [ ! -z $CI_REPO ]
 WVPASS [ ! -z $CI_BRANCH ]
 WVPASS [ ! -z $CI_COMMIT ]
 
+cd $MYTMPDIR
+
 # get_version tests
 export ${CI_SYSTEM}_COMMIT=adc83b19e793491b1c6ea0fd8b46cd9f32e592fc
 export ${CI_SYSTEM}_BRANCH=master
 export ${CI_SYSTEM}_PULL_REQUEST=false
 echo $(Version_Get 1.0.0) > NEW_VERSION
 echo "NEW_VERSION=$(cat NEW_VERSION)"
-WVPASS grep -oP "1.0.0-\d{14}-adc83b1" NEW_VERSION
+WVPASS grep -oE "1.0.0-[0-9]{14}-adc83b1" NEW_VERSION
 rm NEW_VERSION
 
 # On a branch with a / in the name
@@ -41,13 +46,14 @@ export ${CI_SYSTEM}_BRANCH=testbranch
 export ${CI_SYSTEM}_PULL_REQUEST=false
 echo $(Version_Get 1.0.0) > NEW_VERSION
 echo "NEW_VERSION=$(cat NEW_VERSION)"
-WVPASS grep -oP "1.0.0-\d{14}-adc83b1-testbranch" NEW_VERSION
+WVPASS grep -oE "1.0.0-[0-9]{14}-adc83b1-testbranch" NEW_VERSION
 
 # With a pull request
 export ${CI_SYSTEM}_PULL_REQUEST=1234
 echo $(Version_Get 1.0.0) > NEW_VERSION
 echo "NEW_VERSION=$(cat NEW_VERSION)"
-WVPASS grep -oP "1.0.0-\d{14}-adc83b1-PR1234" NEW_VERSION
+WVPASS grep -oE "1.0.0-[0-9]{14}-adc83b1-PR1234" NEW_VERSION
+rm NEW_VERSION
 
 # is_release tests
 # On master
@@ -96,7 +102,7 @@ WVPASS [ $(Hostname_From_Url "https://test2.ports.com:443/some/args?hello") = "t
 # Test atexit
 cat << EOF > .test_lib_ci_atexit.bsh
 #!/bin/bash -x
-. ./lib-ci
+. ../lib-ci
 trap "atexit_commands; exit 0" INT TERM EXIT
 echo "In test script"
 atexit echo "Produced by atexit hook"
@@ -111,7 +117,7 @@ rm .test_lib_ci_atexit.bsh
 # Check the atexit commands don't propagate
 cat << EOF > .test_lib_ci_atexit_fail.bsh
 #!/bin/bash -x
-. ./lib-ci
+. ../lib-ci
 trap "atexit_commands; exit 0" INT TERM EXIT
 EOF
 chmod +x .test_lib_ci_atexit_fail.bsh

--- a/src/tests/test-sbt-ci-build-doc.bsh
+++ b/src/tests/test-sbt-ci-build-doc.bsh
@@ -34,13 +34,13 @@ git symbolic-ref HEAD refs/heads/master || exit 1
 
 # Test that we fail when there is no git remote.
 export FORCE_PUBLISH=yes
-WVFAIL ../../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
+WVFAIL ../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
 
 # Make a git remote to allow the script to find one
 git remote add origin $(readlink -f $TMPREMOTE) || exit 1
 
 # This should now run correctly.
-WVPASS ../../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
+WVPASS ../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
 
 # Remove temporary directories
 rm -rf .gitkeep .git $TMPBASE $TMPREMOTE

--- a/src/tests/test-sbt-ci-build-doc.bsh
+++ b/src/tests/test-sbt-ci-build-doc.bsh
@@ -5,11 +5,13 @@
 # Test framework
 . ./wvtest.sh
 
+. ./lib-ci
+
 # Base dir for sbt
-TMPBASE=$(mktemp -d -p . tmpsbt-ci-build-doc-tmp_sbt_baseXXXXXXXX)
+TMPBASE=$( Mktemp_Portable dir )
 
 # This is our fake remote repo to send documentation to
-TMPREMOTE=$(mktemp -d -p . tmpsbt-ci-build-doc-tmp_git_remote_XXXXXXXX)
+TMPREMOTE=$( Mktemp_Portable dir )
 git init --bare $TMPREMOTE || exit 1
 
 # Test fixtures mean we need to know where we're running
@@ -18,7 +20,10 @@ if [[ ! -d "$SCRIPT_DIR" ]]; then SCRIPT_DIR="$PWD"; fi
 
 # Testing the test fixtures
 ORIG_PWD=$(pwd)
-cd $SCRIPT_DIR/test-sbt-ci-build-doc
+
+# cp our sample project over to the TMPBASE
+cp -av $SCRIPT_DIR/test-sbt-ci-build-doc ${TMPBASE}
+cd $TMPBASE/test-sbt-ci-build-doc
 
 ORIG_CI_BRANCH=$CI_BRANCH
 
@@ -34,15 +39,16 @@ git symbolic-ref HEAD refs/heads/master || exit 1
 
 # Test that we fail when there is no git remote.
 export FORCE_PUBLISH=yes
-WVFAIL ../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
+WVFAIL ${ORIG_PWD}/sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
 
 # Make a git remote to allow the script to find one
-git remote add origin $(readlink -f $TMPREMOTE) || exit 1
+git remote add origin $(readlink_f $TMPREMOTE) || exit 1
 
 # This should now run correctly.
-WVPASS ../sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
+WVPASS ${ORIG_PWD}/sbt-ci-build-doc.bsh "http://testroot" "http://testsourceroot"
+
+cd $ORIG_PWD
 
 # Remove temporary directories
 rm -rf .gitkeep .git $TMPBASE $TMPREMOTE
 
-cd $ORIG_PWD

--- a/src/tests/test-sbt-ci-deploy.bsh
+++ b/src/tests/test-sbt-ci-deploy.bsh
@@ -7,8 +7,7 @@
 
 ORIG_PATH=$PATH
 
-TMPDIR=$(mktemp -d -p . tmpsbt-ci-deploy-tmpXXXXXXXX)
-TMPPATH=$(mktemp -d -p . tmpsbt-ci-deploy-pathXXXXXXXX)
+TMPPATH=$( Mktemp_Portable dir )
 export PATH=$TMPPATH:$ORIG_PATH
 
 # Setup a fake sbt path
@@ -42,4 +41,4 @@ WVPASS ./sbt-ci-deploy.bsh maven http://someurl somerepo project1 project2 proje
 WVPASS ./sbt-ci-deploy.bsh ivy http://someurl somerepo
 WVPASS ./sbt-ci-deploy.bsh ivy http://someurl somerepo project1 project2 project3
 
-rm -rf $TMPPATH $TMPDIR
+rm -rf $TMPPATH

--- a/src/tests/test-sbt-ci-setup-version.bsh
+++ b/src/tests/test-sbt-ci-setup-version.bsh
@@ -3,11 +3,12 @@
 # Test framework
 . ./wvtest.sh
 
-tmpdir=$(mktemp -d -p .)
-echo -e "version in ThisBuild := \"1.0.0\"\nuniqueVersionSettings" > $tmpdir/version.sbt
-cd $tmpdir
-
 . ./lib-ci
+
+MYTMPDIR=$( Mktemp_Portable dir ${PWD} )
+echo -e "version in ThisBuild := \"1.0.0\"\nuniqueVersionSettings" > $MYTMPDIR/version.sbt
+cd $MYTMPDIR
+
 
 versionOrig=$(cat version.sbt)
 # Check command works
@@ -15,12 +16,12 @@ WVPASS ../sbt-ci-setup-version.bsh
 # Check command modifies version
 WVPASSNE "$(cat version.sbt)" "$versionOrig"
 # Check input string comes out broadly correctly.
-WVPASS grep -oP "version in ThisBuild := \"1.0.0.*?\"" version.sbt
+WVPASS grep -oE "version in ThisBuild := \"1.0.0.*?\"" version.sbt
 # Check file has only a single line in it (version string above)
-WVPASS [ "$(cat version.sbt | wc -l)" = "1" ]
+WVPASSEQ   $(cat version.sbt | wc -l)  1
 # Check command fails properly
 rm version.sbt
 WVFAIL ../sbt-ci-setup-version.bsh
 
 cd ..
-rm -rf $tmpdir
+rm -rf $MYTMPDIR

--- a/src/tests/test-setup-version.bsh
+++ b/src/tests/test-setup-version.bsh
@@ -3,9 +3,12 @@
 # Test framework
 . ./wvtest.sh
 
-tmpdir=$(mktemp -d -p .)
-echo "1.0.0" > $tmpdir/VERSION
-cd $tmpdir
+. ./lib-ci
+
+MYTMPDIR=$( Mktemp_Portable dir ${PWD} )
+cd $MYTMPDIR
+
+echo "1.0.0" > VERSION
 
 versionOrig=$(cat VERSION)
 # Check command works
@@ -17,4 +20,4 @@ rm VERSION
 WVFAIL ../setup-version.bsh
 
 cd ..
-rm -rf $tmpdir
+rm -rf $MYTMPDIR


### PR DESCRIPTION
This merge brings 3 significant changes

- all .bsh files are moved into a src/ folder. This meant that some of the logic of tests had to change.
- the tests can execute locally on OSX (and on Linux)
  - this was a multi pronged approach whereby some commands (grep, sed, readlink) had to be executed with "like/for/like" semantics for OSX and Linux. Mostly changes in either tests of lib-ci we added for this
- enhanced the tests to do "temp dirs" and "temp files" consistently using a common "Mktemp_Portable" function in lib-ci. This then enabled a 
   - cleanup routine on test execution.
  - enhancement to - any testing "git" type work is performed in an "out of" project folder (eg /tmp/somepath/fake-repo) 
  