### PR TITLE
Lib ci travis cache

### DIFF
--- a/src/sbt-ci-build-doc.bsh
+++ b/src/sbt-ci-build-doc.bsh
@@ -45,7 +45,7 @@ import lib-ci
 
 CI_Env_Adapt $(CI_Env_Get)
 
-SBT=$(which_sbt)
+SBT=$(which_sbt) || exit 1
 
 # Document URL root
 docUrlRoot="$1"

--- a/src/sbt-ci-deploy.bsh
+++ b/src/sbt-ci-deploy.bsh
@@ -42,7 +42,7 @@ import lib-ci
 
 CI_Env_Adapt $(CI_Env_Get)
 
-SBT=$(which_sbt)
+SBT=$(which_sbt) || exit 1
 
 # Gather the required parameters
 publishStyle=$1

--- a/src/tests/test-sbt-ci-deploy.bsh
+++ b/src/tests/test-sbt-ci-deploy.bsh
@@ -5,6 +5,8 @@
 # Test framework
 . ./wvtest.sh
 
+. ./lib-ci
+
 ORIG_PATH=$PATH
 
 TMPPATH=$( Mktemp_Portable dir )


### PR DESCRIPTION
PR raised for 2nd time to force travis to perform a rebuild.

cache problem in travis-ci has uncovered a bug with path / sbt script locations
this PR fixes both issues.