### PR TITLE
Portable sed

### DIFF
--- a/src/main/bash/bump-docker-version.sh
+++ b/src/main/bash/bump-docker-version.sh
@@ -19,8 +19,8 @@
 set -o nounset
 set -o errexit
 
-[ -e Dockerfile ] && sed -i -r "s|(^FROM $1:).*$|\1$2|g" Dockerfile
+[ -e Dockerfile ] && sed -i.bak "s|\(^FROM $1:\).*$|\1$2|g" Dockerfile
 
 for f in */Dockerfile; do
-  [ -e $f ] && sed -i -r "s|(^FROM $1:).*$|\1$2|g" $f
+  [ -e $f ] && sed -i.bak "s|\(^FROM $1:\).*$|\1$2|g" $f
 done

--- a/src/main/bash/bump-scala-version-depend.sh
+++ b/src/main/bash/bump-scala-version-depend.sh
@@ -19,14 +19,16 @@
 set -o nounset
 set -o errexit
 
+restr="s/\\(.*depend\\.$1(\\\"$2\\\", *\\\"\\)[^\\\"]*/\\1$3/g"
+
 for f in *.sbt; do
-  [ -e $f ] && sed -i -r "s/(.*depend\.$1\(\"$2\", +\")[^\"]+/\1$3/g" $f
+  [ -e $f ] && sed -i.bak "$restr" $f
 done
 
 for f in project/*.scala; do
-  [ -e $f ] && sed -i -r "s/(.*depend\.$1\(\"$2\", +\")[^\"]+/\1$3/g" $f
+  [ -e $f ] && sed -i.bak "$restr" $f
 done
 
 for f in project/*.sbt; do
-  [ -e $f ] && sed -i -r "s/(.*depend\.$1\(\"$2\", +\")[^\"]+/\1$3/g" $f
+  [ -e $f ] && sed -i.bak "$restr" $f
 done

--- a/src/main/bash/bump-scala-version-val.sh
+++ b/src/main/bash/bump-scala-version-val.sh
@@ -19,14 +19,16 @@
 set -o nounset
 set -o errexit
 
+restr="s/\\(.*val $1 *= *\\\"\\)[^\\\"]*/\\1$2/g"
+
 for f in *.sbt; do
-  [ -e $f ] && sed -i -r "s/(.*val $1 += +\")[^\"]+/\1$2/g" $f
+  [ -e $f ] && sed -i.bak "$restr" $f
 done
 
 for f in project/*.scala; do
-  [ -e $f ] && sed -i -r "s/(.*val $1 += +\")[^\"]+/\1$2/g" $f
+  [ -e $f ] && sed -i.bak "$restr" $f
 done
 
 for f in project/*.sbt; do
-  [ -e $f ] && sed -i -r "s/(.*val $1 += +\")[^\"]+/\1$2/g" $f
+  [ -e $f ] && sed -i.bak "$restr" $f
 done

--- a/src/main/bash/bump-scala-version.sh
+++ b/src/main/bash/bump-scala-version.sh
@@ -19,14 +19,16 @@
 set -o nounset
 set -o errexit
 
+restr="s/\\(.*\\\"$1\\\" *%%* *\\\"$2\\\" *% *\\\"\\)[^\\\"]*/\\1$3/g"
+
 for f in *.sbt; do
-  [ -e $f ] && sed -i -r "s/(.*\"$1\" +%?% +\"$2\" +% +\")[^\"]+/\1$3/g" $f
+  [ -e $f ] && sed -i.bak "$restr" $f
 done
 
 for f in project/*.scala; do
-  [ -e $f ] && sed -i -r "s/(.*\"$1\" +%?% +\"$2\" +% +\")[^\"]+/\1$3/g" $f
+  [ -e $f ] && sed -i.bak "$restr" $f
 done
 
 for f in project/*.sbt; do
-  [ -e $f ] && sed -i -r "s/(.*\"$1\" +%?% +\"$2\" +% +\")[^\"]+/\1$3/g" $f
+  [ -e $f ] && sed -i.bak "$restr" $f
 done

--- a/src/main/bash/sbt-ci-build-doc.sh
+++ b/src/main/bash/sbt-ci-build-doc.sh
@@ -71,7 +71,7 @@ function do_build_doc() {
     mkdir -p target/site
 
     echo "Creating documentation..."
-    $SBT -Dsbt.global.base=$CI_BUILD_DIR \
+    $SBT -Dsbt.global.base=$CI_BUILD_DIR/.global-base \
         "set uniform.docRootUrl := \"$docUrlRoot\"" \
         "set uniform.docSourceUrl := \"$docSourceUrlTemplate\"" \
         make-site


### PR DESCRIPTION
Addresses #45 by adding compatibility for BSD sed.

Currently, version bumping assumes GNU sed. This patch:
  - adds support for BSD sed while maintaining compatibility with GNU sed (hopefully),
  - uses more correct regexes in some places (eg. where whitespace is optional),
  - removes duplication of regex strings in several places.